### PR TITLE
logrotate dependency is invalid

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ dependencies:
     repository_url: "deb http://packages.elasticsearch.org/logstash/1.4/debian stable main"
   - role: telusdigital.java
   - role: telusdigital.zeromq
-  - role: package/logrotate
+  - role: telusdigital.logrotate
     logrotate_name: logstash
 galaxy_info:
   author: "Chris Olstrom"


### PR DESCRIPTION
pointing to telusdigital.logrotate instead of package/logrotate (which does not exist anymore)